### PR TITLE
Password encoding | tweaked syntax | 'map' command

### DIFF
--- a/Dungeon.py
+++ b/Dungeon.py
@@ -138,6 +138,16 @@ class Dungeon:
                     print("Not a valid id")
                     continue
 
+            elif words[0] == 'map':
+                if not self.super:
+                    print("must be super user to do that try: \'super\'")
+                    continue
+                self.c.execute('SELECT * FROM rooms')
+                x = self.c.fetchall()
+                print("id| Description | Long Description | Users? | Loot")
+                for i in x:
+                    print("{} | {} | {}".format(i[0],i[1], i[2]))
+
             elif words[0] == 'inspect':
                 if self.super: # inspect any item
                     self.c.execute("SELECT name FROM loot".format(self.current_room))

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -354,6 +354,7 @@ class Dungeon:
         if correct is None or len(correct) < 4:
             print("Incorrect password for user")
             self.login()
+            return None
         if correct[4] == 1:
             self.prompt =  RED + self.user + " ! "+RESET
             self.super = True

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -58,14 +58,13 @@ class Dungeon:
             elif words[0] == 'look':
                 self.doLook()
 
-            elif words[0] == 'go':
+            elif words[0] == 'go' or words[0] in DIRECTIONS:
                 # move to an adjacent room.
-                # todo - allow someone to type the direction of an
-                # adjacent room without "go"
-                if len(words) < 2:
+                if len(words) < 2 and words[0] not in DIRECTIONS:
                     print("usage: go <direction>")
                     continue
-                self.c.execute("SELECT to_room FROM exits WHERE from_room = {} AND dir='{}'".format(self.current_room, words[1]))
+                dir = words[0] if words[0] in DIRECTIONS else words[1]
+                self.c.execute("SELECT to_room FROM exits WHERE from_room = {} AND dir='{}'".format(self.current_room, dir))
                 new_room_p = self.c.fetchone()
                 if new_room_p is None:
                     print("You can't go that way")

--- a/Dungeon.py
+++ b/Dungeon.py
@@ -126,13 +126,14 @@ class Dungeon:
                 if not self.super:
                     print("must be super user to do that try: \'super\'")
                     continue
+                if len(words) < 2:
+                    print("need a room id")
+                    continue
                 self.c.execute('SELECT id FROM rooms')
                 x = [row[0] for row in self.c.fetchall()]
-                print(x)
-                y = int(input("Pick room id to teleport to: "))
-                if y in x:
-                    self.current_room = y
-                    print("You teleported!")
+                if int(words[1]) in x:
+                    self.current_room = int(words[1])
+                    print(BLUE + "You teleported!" + RESET)
                     self.doLook()
                 else:
                     print("Not a valid id")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features:
 
 Setup:
 ```
-python3 Dungeon.py < setup.txt
+p3 dungeon.py < setup.txt > /dev/null
 ```
 - Modify setup.txt to change layout of a generated map
 - Use super user to make changes to an existing map

--- a/setup.txt
+++ b/setup.txt
@@ -11,19 +11,19 @@ loot knife 3 | Useful for chopping
 place spear
 dig east west | A small room | Pretty Normal
 dig up down | The Kitchen | It smells pretty good...
-go east
+east
 place torch
 spawn wizard 20 sword
 dig north south | A large dinning hall | Sadly empty of food
-go north
+north
 spawn knight 25 spear
 dig east west | The Armory | Stock full of weapons
-go east
+east
 place lance
 spawn knight 40 axe
 tele
 1
-go up
+up
 spawn chef 10 knife
 tele
 1


### PR DESCRIPTION
- Encode passwords before putting into sql table (not secure)
- Added 'map' command for super uses to see all room ids
- Changed tele syntax to take room id instead of listing them (redundant given new 'map' command)
- Added quick go commands i.e. west instead of go west for commands in DIRECTIONS ['west','east','south','north','up','down']